### PR TITLE
read palette name from config

### DIFF
--- a/pykrita/QuickColor/QuickColor.py
+++ b/pykrita/QuickColor/QuickColor.py
@@ -4,22 +4,25 @@ from PyQt5.QtWidgets import QErrorMessage
 
 class QuickColorExtension(Extension):
 
-    def __init__(self, parent, paletteName):
+    def __init__(self, parent):
         #Initialising the parent, important when subclassing
         super().__init__(parent)
-        self.paletteName = paletteName
 
     def setup(self):
         pass
+
+    def paletteName(self):
+        #read name of palette from kritarc, defaulting to "QuickColor" if not found
+        return Krita.instance().readSetting("QuickColorExtension", "Palette", "QuickColor")
 
     def swap(self, index):
         #Swaps the foreground color to a color from the palette called self.paletteName, by index
         view = Krita.instance().activeWindow().activeView()
         resources = Application.resources("palette")
-        res = resources.get(self.paletteName, None)
+        res = resources.get(self.paletteName(), None)
         if res is None:
             em = QErrorMessage()
-            em.showMessage("You need a palette named \"" + self.paletteName + "\" for the QuickColorExtension to work")
+            em.showMessage(f"You need a palette named \"{self.paletteName()}\" (configurable in kritarc) for the QuickColorExtension to work.")
             em.exec_()
         else:
             palette = Palette(res)
@@ -27,10 +30,10 @@ class QuickColorExtension(Extension):
             view.setForeGroundColor(color)
 
     def createActions(self, window):
-        for n in range(4):
+        for n in range(5):
             name = "QuickColor" + str(n)
             action = window.createAction(name, name)
             action.triggered.connect(functools.partial(self.swap, n))
 
 #Adding extension to Krita's list of extensions
-Krita.instance().addExtension(QuickColorExtension(Krita.instance(), "QuickColor"))
+Krita.instance().addExtension(QuickColorExtension(Krita.instance()))


### PR DESCRIPTION
Hi,

I figured out how to use the krita-configfile (located in ~/.config/kritarc on my system).
This could be used to configure the palette-name - in kirtarc it would look like:

[QuickColorExtension]
Palette=AnotherQuickColor

You could also write to this file with writeSetting() - so it would be an easy exercise to have a configuration dialog.

And range(4) only runs up to 3 - it must be range(5) to create 4 actions.